### PR TITLE
Refactor server y refrescar tokens

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,28 +1,36 @@
 const jwt = require("jsonwebtoken");
+const { refrescarToken } = require('./tokenUtils.js')
+
 
 // Middleware per verificar el token i obtenir l'ID de l'usuari
 function verificaToken(req, res, next) {
-    const authorizationHeader = req.headers.authorization;
+    const authorizationHeader = req.cookies['token'];
+    const refreshToken = req.cookies['refreshToken'];
 
-    if (!authorizationHeader) {
+    if (!authorizationHeader && !refreshToken) {
         return res.status(401).json({ error: 'Token no proporcionat' });
     }
-
     try {
-        // Separa el prefix "Bearer" i el token
-        const [bearer, token] = authorizationHeader.split(' ');
-
-        // Verifica que s'ha proporcionat el token correctament
-        if (!token || bearer.toLowerCase() !== 'bearer') {
-            throw new Error('Token invàlid');
-        }
-
-        //Guarda id_usuari del token descodificat
-        const decodedToken = jwt.verify(token, process.env.JWT_SECRET);
-        req.idUsuariToken = decodedToken.usuario.id_usuari;
+        const decodedToken = jwt.verify(authorizationHeader, process.env.JWT_SECRET);
+        req.usuario = decodedToken.usuario;
         next();
     } catch (error) {
-        return res.status(401).json({ error: error.message });
+        if (!refreshToken) {
+            return res.status(401).send('No hay token de refresco');
+        }
+        try {
+            const { accessToken, usuario, error: refreshError } = refrescarToken(refreshToken);
+            if (refreshError) {
+                res.status(302).json({ redirectTo: "http://solaria.website" }) //Debe redirigir a la pagina de login para conseguir dos nuevos token
+            }
+            req.usuario = usuario;
+            res
+                .cookie('refreshToken', refreshToken, { httpOnly: true, sameSite: 'strict' })
+                .cookie('token', accessToken, { httpOnly: true, sameSite: 'strict' });
+            next();
+        } catch (error) {
+            return res.status(400);
+        }
     }
 }
 

--- a/immobles.js
+++ b/immobles.js
@@ -1,9 +1,7 @@
 const express = require("express");
-const bcrypt = require("bcrypt");
-const jwt = require("jsonwebtoken");
 const db = require('./database');
 const verificaToken = require('./auth');
-const login = require('./login.js');
+
 
 const immobles = express();
 immobles.use(express.json());
@@ -14,18 +12,18 @@ immobles.get('/immobles', async (req, res) => {
     try {
         db.query('SELECT * FROM immobles', (err, results) => {
             if (err) {
-                console.log("Error:", err); 
+                console.log("Error:", err);
                 return res.status(500).json("Error del servidor");
-            } 
+            }
             if (!results || results.length === 0) {
                 return res.status(404).json({ error: 'No se encontraron resultados' });
             }
 
             res.send(results);
-            
+
         });
     } catch (err) {
-        console.log("Error en el bloc catch:", err); 
+        console.log("Error en el bloc catch:", err);
         res.status(500).json("Error del servidor");
     }
 });
@@ -38,13 +36,13 @@ immobles.get('/immobles/codi_postal/:codiPostal', async (req, res) => {
             if (err) {
                 console.error("Error:", err);
                 return res.status(500).json("Error del servidor");
-            } 
+            }
             if (!results || results.length === 0) {
                 return res.status(404).json({ error: 'No se encontraron resultados' });
             }
-            
+
             res.send(results);
-            
+
         });
     } catch (err) {
         console.error("Error en el bloc catch:", err);
@@ -60,13 +58,13 @@ immobles.get('/immobles/poblacio/:poblacio', async (req, res) => {
             if (err) {
                 console.error("Error:", err);
                 return res.status(500).json("Error del servidor");
-            } 
+            }
             if (!results || results.length === 0) {
                 return res.status(404).json({ error: 'No se encontraron resultados' });
             }
 
             res.send(results);
-            
+
         });
     } catch (err) {
         console.error("Error en el bloc catch:", err);
@@ -77,7 +75,7 @@ immobles.get('/immobles/poblacio/:poblacio', async (req, res) => {
 // Endpoint per obtenir la llista d'immobles segons l'ID de l'usuari del token  (R)
 immobles.get('/immobles/usuari', verificaToken, async (req, res) => {
     try {
-        const idUsuariToken = req.idUsuariToken;
+        const idUsuariToken = req.usuario.id_usuari;
 
         db.query('SELECT * FROM immobles WHERE id_usuari = ?', [idUsuariToken], (error, results) => {
             if (error) {
@@ -101,7 +99,7 @@ immobles.post('/immobles/afegir', verificaToken, async (req, res) => {
     try {
         //Recollim dades de l'immoble del body, excepte id_usuari que l'agafa del token
         const { Carrer, Numero, Pis, Codi_Postal, Poblacio, Descripcio, Preu, Imatge } = req.body;
-        const id_usuari = req.idUsuariToken;
+        const id_usuari = req.usuario.id_usuari;
 
         // Consulta SQL per afegir un nou immoble a la bbdd amb l'id de l'usuari autenticat
         db.query('INSERT INTO immobles (id_usuari, Carrer, Numero, Pis, Codi_Postal, Poblacio, Descripcio, Preu, Imatge) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)', [id_usuari, Carrer, Numero, Pis, Codi_Postal, Poblacio, Descripcio, Preu, Imatge], (err, result) => {

--- a/login.js
+++ b/login.js
@@ -22,7 +22,11 @@ login.post('/login', async (req, res) => {
             return res.status(400).json({ error: 'Credenciales incorrectas' });
         }
         const token = jwt.sign({ usuario }, process.env.JWT_SECRET, { expiresIn: '1h' });
-        res.json({ token });
+        const refreshToken = jwt.sign({ usuario }, process.env.JWT_SECRET, { expiresIn: '1d' });
+        res
+            .cookie('refreshToken', refreshToken, { httpOnly: true, sameSite: 'strict' })
+            .cookie('token', token, { httpOnly: true, sameSite: 'strict' })
+            .send("Inicio de sesión exitoso");
     });
 });
 module.exports = login;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^5.1.1",
+        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "ejs": "^3.1.9",
@@ -1767,6 +1768,26 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -6377,6 +6398,22 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+    },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "bcrypt": "^5.1.1",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "ejs": "^3.1.9",

--- a/server.js
+++ b/server.js
@@ -1,91 +1,22 @@
 const express = require("express");
 const cors = require("cors");
-const bcrypt = require('bcrypt');
 const login = require("./login.js")
-const db = require('./database');
-const immobles = require("./immobles.js")
+const immobles = require("./immobles.js");
+const usuaris = require("./usuaris.js");
 
 
 const app = express();
 app.use(cors());
-app.use(express.json());
-app.use('/', login)
+app.use('/', login);
 app.use('/', immobles);
-
-
-
-app.get('/app', async (req, res) => {
-    db.query('SELECT * FROM usuaris', (err, results) => {
-        if (err) {
-            console.log("Error");
-            return res.status(500).send("Error")
-        } else {
-            res.send(results);
-        }
-    });
-})
-
-app.get('/app/:id', async (req, res) => {
-    try {
-        const id = req.params.id;
-        db.query('SELECT * FROM usuaris where id_usuari = ?', id, (error, results) => {
-            if (error) {
-                console.log("Error:", error);
-                return res.status(500).send("Server Error");
-            } else {
-                if (results.length > 0) {
-                    res.send(results[0]);
-                } else {
-                    res.status(404).send("Not found");
-                }
-            }
-        });
-    } catch (err) {
-        console.log("Catch block error:", err);
-        res.status(500).send("Server Error");
-    }
-});
-
-
-
-app.post('/app/registre', async (req, res) => {
-    const { Email, Nom, Cognoms, Contrasenya, TipusUsuari } = req.body;
-    bcrypt.hash(Contrasenya, 10, (err, hashedPassword) => {
-        if (err) {
-            console.log("Error hashing password:", err);
-            return res.status(500).send({ error: 'Error hashing password' });
-        }
-
-        const queryComprobar = 'SELECT id_usuari FROM usuaris WHERE Email = ?';
-        db.query(queryComprobar, [Email], (error, results) => {
-            if (error) {
-                res.status(500).send({ error: 'Error encontrando usuario' });
-                return;
-            }
-            if (results.length === 0) {
-                const queryInsertarUsuario = 'INSERT INTO usuaris (Email, Nom, Cognoms, Contrasenya, TipusUsuari) VALUES (?, ?, ?, ?, ?)';
-                db.query(queryInsertarUsuario, [Email, Nom, Cognoms, hashedPassword, TipusUsuari], (err, result) => {
-                    if (err) {
-                        console.log("Error creando la tabla");
-                        res.status(500).send({ error: 'Error creando la tabla' });
-                        return;
-                    }
-                    res.status(200).send("Usuario creado con éxito");
-                });
-            } else {
-                res.status(400).send('El usuario ya existe');
-            }
-        });
-    });
-});
-
+app.use('/', usuaris);
 
 if (require.main === module) {
     const PORT = process.env.PORT || 3333;
     app.listen(PORT, () => {
         console.log(`Server is running at PORT: ${PORT}`);
     });
-  }
+}
 
 module.exports = app;
 

--- a/server.js
+++ b/server.js
@@ -3,13 +3,17 @@ const cors = require("cors");
 const login = require("./login.js")
 const immobles = require("./immobles.js");
 const usuaris = require("./usuaris.js");
+const cookieParser = require('cookie-parser');
+
 
 
 const app = express();
 app.use(cors());
+app.use(cookieParser());
 app.use('/', login);
 app.use('/', immobles);
 app.use('/', usuaris);
+
 
 if (require.main === module) {
     const PORT = process.env.PORT || 3333;

--- a/tokenUtils.js
+++ b/tokenUtils.js
@@ -1,0 +1,14 @@
+const jwt = require("jsonwebtoken");
+
+function refrescarToken(refreshToken) {
+    try {
+        const decoded = jwt.verify(refreshToken, process.env.JWT_SECRET);
+        const accessToken = jwt.sign({ usuario: decoded.usuario }, process.env.JWT_SECRET, { expiresIn: '1h' });
+        const decodedToken = jwt.verify(accessToken, process.env.JWT_SECRET);
+        return { accessToken, usuario: decodedToken.usuario };
+    } catch (error) {
+        return { error: 'Tienes que hacer login de nuevo' };
+    }
+}
+
+module.exports = { refrescarToken };

--- a/usuaris.js
+++ b/usuaris.js
@@ -1,0 +1,74 @@
+const express = require("express");
+const bcrypt = require('bcrypt');
+const db = require('./database');
+
+
+const usuaris = express();
+usuaris.use(express.json())
+
+usuaris.get('/app', async (req, res) => {
+    db.query('SELECT * FROM usuaris', (err, results) => {
+        if (err) {
+            console.log("Error");
+            return res.status(500).send("Error")
+        } else {
+            res.send(results);
+        }
+    });
+})
+
+usuaris.get('/app/:id', async (req, res) => {
+    try {
+        const id = req.params.id;
+        db.query('SELECT * FROM usuaris where id_usuari = ?', id, (error, results) => {
+            if (error) {
+                console.log("Error:", error);
+                return res.status(500).send("Server Error");
+            } else {
+                if (results.length > 0) {
+                    res.send(results[0]);
+                } else {
+                    res.status(404).send("Not found");
+                }
+            }
+        });
+    } catch (err) {
+        console.log("Catch block error:", err);
+        res.status(500).send("Server Error");
+    }
+});
+
+
+
+usuaris.post('/app/registre', async (req, res) => {
+    const { Email, Nom, Cognoms, Contrasenya, TipusUsuari } = req.body;
+    bcrypt.hash(Contrasenya, 10, (err, hashedPassword) => {
+        if (err) {
+            console.log("Error hashing password:", err);
+            return res.status(500).send({ error: 'Error hashing password' });
+        }
+
+        const queryComprobar = 'SELECT id_usuari FROM usuaris WHERE Email = ?';
+        db.query(queryComprobar, [Email], (error, results) => {
+            if (error) {
+                res.status(500).send({ error: 'Error encontrando usuario' });
+                return;
+            }
+            if (results.length === 0) {
+                const queryInsertarUsuario = 'INSERT INTO usuaris (Email, Nom, Cognoms, Contrasenya, TipusUsuari) VALUES (?, ?, ?, ?, ?)';
+                db.query(queryInsertarUsuario, [Email, Nom, Cognoms, hashedPassword, TipusUsuari], (err, result) => {
+                    if (err) {
+                        console.log("Error creando la tabla");
+                        res.status(500).send({ error: 'Error creando la tabla' });
+                        return;
+                    }
+                    res.status(200).send("Usuario creado con éxito");
+                });
+            } else {
+                res.status(400).send('El usuario ya existe');
+            }
+        });
+    });
+});
+
+module.exports = usuaris;

--- a/usuaris.test.js
+++ b/usuaris.test.js
@@ -1,7 +1,7 @@
 const request = require('supertest');
-const app = require("./server")
+const app = require("./server.js")
 const login = require('./login.js');
-const db = require('./database');
+const db = require('./database.js');
 
 jest.mock('./database', () => {
     return {


### PR DESCRIPTION
Hola.

Esta PR separa la logica de usuarios de server y se encarga de crear la logica para refrescar el token que le entregamos al usuario. Voy a intentar explicar los cambios:

Por motivos de seguridad, cuando un usuario hace login la token, que dura 1 hora ya no se entrega en Json, si no que se almacena como una cookie llamada "token". Además, al hacer login, un usuario obtiene una token de refresco, que se guarda en una cookie llamada "refreshToken" y que dura de momento 1 dia. 

Esta token de refresco hace que cuando una solicitud usa la token normal y esta ha caducado, se asigne de forma inmediata una nueva token de usuario que durará 1 hora igual que la que obtiene al hacer login. Mientras la token de refresco  no haya caducado, un usuario que no haga logout podrá seguir haciendo peticiones sin problema, obteniendo nuevas token. 

Una vez la token de refresco caduca, al comprobar si la token es valida cuando el usuario hace una solicitud, la idea es que rediriga al usuario a la pagina de login para que se vuelva a loguear y empiece el ciclo de nuevo. Esa redirección la tendréis que gestionar desde el frontend. El back envia un redirectTo que podeis aprovechar creo.

A la hora de hacer pruebas, vereis que cuando haceis un login mediante postman, automaticamente rescata las dos cookies y las usará en las solicitudes apropiadas sin que tengais que hacer nada, lo cual es más comodo que el otro metodo que usabamos.

Si quereis comprobar el funcionamiento por vosotros mismos en local, debeis editar el tiempo de caducidad de las cookies a 1 minuto. Esto podeis hacerlo cambiando cualquier linea similar a:

const refreshToken = jwt.sign({ usuario }, process.env.JWT_SECRET, { expiresIn: '1d' });

Y cambiando el 1d por 1m. Hay lineas así en:

login.js
tokenUtils.js

Esta es la primera iteración, así que cualquier duda o error que haya podido pasar por alto me lo comentais.

Un saludo.