### PR TITLE
Añadida paginación para los inmuebles que se muestran en el frontend.

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -2,27 +2,41 @@ const db = require('./database');
 
 // Crear objectes Mocks
 const crearObjectesMock = (params) => {
-    const req = { params };
-    const res = {
-      status: jest.fn(() => res),
-      json: jest.fn(),
-    };
-    const next = jest.fn();
-    return { req, res, next };
+  const req = { params };
+  const res = {
+    status: jest.fn(() => res),
+    json: jest.fn(),
+  };
+  const next = jest.fn();
+  return { req, res, next };
+};
+
+// Verifica si un immoble existeix a la bbdd
+function verificaExisteixImmoble(id_immoble, callback) {
+  const query = 'SELECT COUNT(*) AS count FROM Immobles WHERE id_immoble = ?';
+  db.query(query, [id_immoble], (error, result) => {
+    if (error) {
+      console.error('Error al verificar la existencia del inmueble:', error);
+      callback(error, null);
+    } else {
+      const existeix = result[0].count > 0;
+      callback(null, existeix);
+    }
+  });
+}
+
+function paginateResults(req, res, next) {
+  const page = parseInt(req.query.page) || 1;
+  const limit = parseInt(req.query.limit) || 10;
+  const offset = (page - 1) * limit;
+
+  req.pagination = {
+    limit,
+    offset,
+    currentPage: page // Añadimos el número de la página actual al objeto de paginación
   };
 
-  // Verifica si un immoble existeix a la bbdd
-  function verificaExisteixImmoble(id_immoble, callback) {
-    const query = 'SELECT COUNT(*) AS count FROM Immobles WHERE id_immoble = ?';
-    db.query(query, [id_immoble], (error, result) => {
-      if (error) {
-        console.error('Error al verificar la existencia del inmueble:', error);
-        callback(error, null);
-      } else {
-        const existeix = result[0].count > 0;
-        callback(null, existeix);
-      }
-    });
-  }
+  next();
+}
 
-module.exports = { crearObjectesMock, verificaExisteixImmoble };
+module.exports = { crearObjectesMock, verificaExisteixImmoble, paginateResults };


### PR DESCRIPTION
A la hora de hacer la request, sería algo así

http://localhost:3333/immobles/codi_postal/08001?page=1&limit=1

El termino page es la pagina a mostrar y el termino limit el numero de resultados que quereis en cada pagina. Si no poneis un limite de resultados, el número por defecto es 10

Dentro del json de respuesta hay un apartado llamado pagination que tiene todos los datos relevantes como explico a continuacion. Por ejemplo, con la solicitud que os he puesto arriba, daría:

  "pagination": {
        "totalResults": 4,
        "totalPages": 4,
        "currentPage": 1,
        "nextPage": 2,
        "prevPage": null
    }

Lo que devuelve cambia dinamicamente según lo que esté puesto en page y limit.

En las pruebas con postman funciona correctamente, con lo que entiendo que en el front os debería funcionar bien, cualquier cosa me decís.